### PR TITLE
Fix(build): Resolve all build and dependency issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Clean old builds
         run: rm $GITHUB_WORKSPACE/builds/*.cs3 || true
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17 for SDK Manager
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
@@ -79,6 +79,12 @@ jobs:
           echo SUPERSTREAM_SECOND_API=$SUPERSTREAM_SECOND_API >> local.properties
           echo SUPERSTREAM_THIRD_API=$SUPERSTREAM_THIRD_API >> local.properties
           echo SUPERSTREAM_FOURTH_API=$SUPERSTREAM_FOURTH_API >> local.properties
+
+      - name: Setup JDK 11 for Gradle
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 11
 
       - name: Build Plugins
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,10 +10,10 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.3")
         // Cloudstream gradle plugin which makes everything work and builds plugins
         classpath("com.github.recloudstream:gradle:-SNAPSHOT")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
     }
 }
 
@@ -79,7 +79,7 @@ subprojects {
         implementation(kotlin("stdlib")) // adds standard kotlin features, like listOf, mapOf etc
         implementation("com.github.Blatzar:NiceHttp:0.4.11") // http library
         implementation("org.jsoup:jsoup:1.17.2") // html parser
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
         implementation("io.karn:khttp-android:0.1.2")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
         implementation("org.mozilla:rhino:1.7.14") //run JS


### PR DESCRIPTION
This commit resolves a cascade of build failures by addressing multiple issues in the build configuration and CI workflow.

1.  **Downgrade Jackson Dependency:** Downgrades `jackson-module-kotlin` from 2.16.1 to 2.15.2. The newer version is compiled with Java 21, which is incompatible with the project's Jetifier tool.

2.  **Upgrade Kotlin Version:** Upgrades the Kotlin version from 1.9.22 to 2.0.0. This is necessary to resolve a compilation error caused by a dependency (`cloudstream`) being compiled with a newer version of Kotlin.

3.  **Upgrade Android Gradle Plugin:** Upgrades the Android Gradle Plugin from 7.0.4 to 7.1.3. This is required by the new Kotlin version.

4.  **Fix CI Workflow:** Updates the GitHub Actions workflow to use both Java 17 (for the SDK manager) and Java 11 (for the Gradle build) to resolve a conflict in the CI environment.